### PR TITLE
Call super onBackPressed to preserve bubble

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/BubbleActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/BubbleActivity.java
@@ -299,6 +299,7 @@ public class BubbleActivity extends Activity implements ActionBarLayout.ActionBa
 
     @Override
     public void onBackPressed() {
+        super.onBackPressed();
         if (passcodeView.getVisibility() == View.VISIBLE) {
             finish();
             return;


### PR DESCRIPTION
fix bubble from disappearing on backpress because it doesn't call super.

To repro: Have a msg bubble and press back. Bubble disappears as opposed to collapsing into a non expanded bubble.